### PR TITLE
Update Node 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ output:
     description: 'Data read from YAML file'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub is [deprecating Node 12 for GitHub actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This also removes the deprecation notice seen when running an action that uses Node 12.